### PR TITLE
Quick & dirty scripts to ease committing of contributions

### DIFF
--- a/bin/list_unchanged_crowdin_files.php
+++ b/bin/list_unchanged_crowdin_files.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+// lists the files from the current branch that only change the timestamp
+foreach (explode(PHP_EOL, `git diff master.. --stat --stat-width=100`) as $line)
+{
+    if (preg_match('/\s+([^\|]+)\s+\|\s+2\s/', $line, $m)) {
+        echo "$m[1]\n";
+    }
+}

--- a/bin/split_language_commits.php
+++ b/bin/split_language_commits.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+// analyzes changes from l10n_master against the current branch
+// and outputs commands to checkout & commit each language separately
+
+try {
+    $translations = getLanguagesData();
+} catch (Exception $e) {
+    echo "An error occurred: " . $e->getMessage() . "\n";
+    exit(1);
+}
+
+foreach (explode(PHP_EOL, `git diff ..l10n_master --name-only`) as $file)
+{
+    if (!preg_match('|translations/([a-z]{2,3}_[a-z]{2,3})/.*\.xlf|i', $file, $m)) {
+        continue;
+    }
+
+    $directory = $m[1];
+
+    if (!isset($translations[$directory])) {
+        continue;
+    }
+
+    $translations[$directory]['files'][] = $file;
+}
+
+foreach ($translations as $directory => $data) {
+    if (!isset($data['files'])) {
+        printf(
+            "No changes to %s (%d%% translated, %d%% approved)\n",
+            $data['name'],
+            $data['status']['translated_progress'],
+            $data['status']['approved_progress']
+        );
+        continue;
+    }
+
+    printf(
+        "git checkout l10n_master translations/%s/\n",
+        $directory
+    );
+    printf(
+        "git commit -m \"%s translation (%d%% translated, %d%% approved)\"\n",
+        $data['name'],
+        $data['status']['translated_progress'],
+        $data['status']['approved_progress']
+    );
+}
+
+
+function getLanguagesData()
+{
+    $languagesMap= [
+        'de' => 'de_DE',
+        'el' => 'el_GR',
+        'es-ES' => 'es_ES',
+        'fi' => 'fi_FI',
+        'fr' => 'fr_FR',
+        'hi' => 'hi_IN',
+        'hu' => 'hu_HU',
+        'ja' => 'ja_JP',
+        'nb' => 'nb_NO',
+        'pl' => 'pl_PL',
+        'pt-PT' => 'pt_PT',
+        'ru' => 'ru_RU',
+    ];
+
+    if (!$crowdinApiKey = getenv('CROWDIN_API_KEY')) {
+        throw new InvalidArgumentException("Environment variable CROWDIN_API_KEY must be set for the ezplatform project");
+    }
+
+    $statuses = json_decode(
+        file_get_contents(
+            "https://api.crowdin.com/api/project/ezplatform/status?key=$crowdinApiKey&json"
+        )
+    );
+    if ($statuses instanceof stdClass) {
+        throw new Exception("Unexpected response from crowdin API");
+    }
+
+    $languagesData = [];
+
+    foreach ($statuses as $status) {
+        if (!isset($languagesMap[$status->code])) {
+            throw new Exception("No mapping found for language code $status->code\n");
+        }
+
+        $directory = $languagesMap[$status->code];
+
+        $languagesData[$directory] = [
+            'name' => $status->name,
+            'status' => (array)$status,
+        ];
+    }
+
+    return $languagesData;
+}


### PR DESCRIPTION
`bin/list_unchanged_crowdin_files.php` will list the files where only the timestamp was changed, so that they can be reverted.

` bin/split_language_commits.php` will output a set of git commands to commit each language separately. It also uses the crowdin API to add the translated/approved progress % on each commit message. Example

```
Spanish translation (33% translated, 0% approved)
Portuguese translation (100% translated, 100% approved)
Polish translation (100% translated, 100% approved)
Norwegian Bokmal translation (81% translated, 0% approved)
Japanese translation (20% translated, 0% approved)
Hungarian translation (86% translated, 0% approved)
Hindi translation (17% translated, 0% approved)
Greek translation (19% translated, 0% approved)
German translation (34% translated, 0% approved)
French translation (100% translated, 33% approved)
Finnish translation (4% translated, 0% approved)
```