### PR TITLE
Moved translation sync script from ezplatform

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,35 +27,6 @@ One way to do this is to open the development console (right click, inspect) and
 
     document.cookie='ez_in_context_translation=;expires=Mon, 05 Jul 2000 00:00:00 GMT;path=/;'; location.reload();
 
-## Repository split
-
-Each locale will be stored in its own repository in [ezplatform-i18n organisation][ezplatform-i18n-org].
-
-This synchronisation is done using [dflydev/git-subsplit][dflydev] tool.
-
-    git subsplit init https://github.com/ezsystems/ezplatform-i18n
-    git subsplit update
-    git subsplit publish "
-        translations/ach_UG:git@github.com:ezplatform-i18n/ezplatform-i18n-ach_UG.git
-        translations/de_DE:git@github.com:ezplatform-i18n/ezplatform-i18n-de_DE.git
-        translations/es_ES:git@github.com:ezplatform-i18n/ezplatform-i18n-es_ES.git
-        translations/el_GR:git@github.com:ezplatform-i18n/greek.git
-        translations/fi_FI:git@github.com:ezplatform-i18n/ezplatform-i18n-fi_FI.git
-        translations/fr_FR:git@github.com:ezplatform-i18n/ezplatform-i18n-fr_FR.git
-        translations/hi_IN:git@github.com:ezplatform-i18n/ezplatform-i18n-hi_IN.git
-        translations/hu_HU:git@github.com:ezplatform-i18n/ezplatform-i18n-hu_HU.git
-        translations/ja_JP:git@github.com:ezplatform-i18n/ezplatform-i18n-ja_JP.git
-        translations/nb_NO:git@github.com:ezplatform-i18n/ezplatform-i18n-nb_NO.git
-        translations/no_NO:git@github.com:ezplatform-i18n/ezplatform-i18n-no_NO.git
-        translations/pl_PL:git@github.com:ezplatform-i18n/ezplatform-i18n-pl_PL.git
-        translations/pt_PT:git@github.com:ezplatform-i18n/ezplatform-i18n-pt_PT.git
-        translations/ru_RU:git@github.com:ezplatform-i18n/ezplatform-i18n-ru_RU.git
-        translations/it_IT:git@github.com:ezplatform-i18n/ezplatform-i18n-it_IT.git
-        translations/en_US:git@github.com:ezplatform-i18n/ezplatform-i18n-en_US.git
-        translations/nl:git@github.com:ezplatform-i18n/dutch.git
-        translations/he:git@github.com:ezplatform-i18n/hebrew.git
-    " --heads=master
-
 ## Copyright & License
 Copyright (c) eZ Systems AS. For copyright and license details see provided LICENSE file.
 

--- a/bin/split_language_commits.php
+++ b/bin/split_language_commits.php
@@ -36,7 +36,6 @@ foreach ($translations as $directory => $data) {
     if (!isset($data['files'])) {
         $commands[] = sprintf(
             '# No changes (%d%% translated, %d%% approved)',
-            $data['name'],
             $data['status']['translated_progress'],
             $data['status']['approved_progress']
         );

--- a/bin/synchronize-translations.sh
+++ b/bin/synchronize-translations.sh
@@ -1,44 +1,50 @@
 #!/usr/bin/env sh
-# This script should be used to synchronize ezplatform-i18n repository
-# Translations must be up-to-date in all packages
-echo 'Translation synchronization';
+# Synchronize translation sources from all packages to ezplatform-i18n
+echo '# Translation synchronization';
 
-echo '# Clean corresponding ezplatform-i18n folder';
-rm -rf ./vendor/ezsystems/ezplatform-i18n/ezplatform-admin-ui/*.xlf
-rm -rf ./vendor/ezsystems/ezplatform-i18n/ezpublish-kernel/*.xlf
-rm -rf ./vendor/ezsystems/ezplatform-i18n/repository-forms/*.xlf
 
 echo '# Mirror the translation files';
-cp ./vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/translations/*.xliff ./vendor/ezsystems/ezplatform-i18n/ezplatform-admin-ui
-cp ./vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishCoreBundle/Resources/translations/*.xlf ./vendor/ezsystems/ezplatform-i18n/ezpublish-kernel
-cp ./vendor/ezsystems/repository-forms/bundle/Resources/translations/*.xlf ./vendor/ezsystems/ezplatform-i18n/repository-forms
 
-echo '# Fixing .xlf extensions'
-rename -s '.xliff' '.xlf' vendor/ezsystems/ezplatform-i18n/ezplatform-admin-ui/*
+echo "ezsystems/ezplatform-admin-ui"
+rm -f ./vendor/ezsystems/ezplatform-i18n/ezplatform-admin-ui/*
+cp ./vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/translations/* ./vendor/ezsystems/ezplatform-i18n/ezplatform-admin-ui
+
+echo "ezsystems/ezpublish-kernel"
+rm -f ./vendor/ezsystems/ezplatform-i18n/ezpublish-kernel/*
+cp ./vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishCoreBundle/Resources/translations/* ./vendor/ezsystems/ezplatform-i18n/ezpublish-kernel
+
+echo "ezsystems/repository-forms"
+rm -f ./vendor/ezsystems/ezplatform-i18n/repository-forms/*
+cp ./vendor/ezsystems/repository-forms/bundle/Resources/translations/* ./vendor/ezsystems/ezplatform-i18n/repository-forms
 
 if [ -d "./vendor/ezsystems/date-based-publisher" ]; then
-  echo "Sync ezsystems/date-based-publisher"
-  rm ./vendor/ezsystems/ezplatform-i18n/date-based-publisher/*.xlf
-  cp ./vendor/ezsystems/date-based-publisher/bundle/Resources/translations/*.xlf ./vendor/ezsystems/ezplatform-i18n/date-based-publisher
+  echo "ezsystems/date-based-publisher"
+  rm -f ./vendor/ezsystems/ezplatform-i18n/date-based-publisher/*
+  cp ./vendor/ezsystems/date-based-publisher/bundle/Resources/translations/* ./vendor/ezsystems/ezplatform-i18n/date-based-publisher
 fi
 
 if [ -d "./vendor/ezsystems/flex-workflow" ]; then
-  echo "Sync ezsystems/flex-workflow"
-  rm ./vendor/ezsystems/ezplatform-i18n/flex-workflow/*.xlf
-  cp ./vendor/ezsystems/flex-workflow/bundle/Resources/translations/*.xlf ./vendor/ezsystems/ezplatform-i18n/flex-workflow
+  echo "ezsystems/flex-workflow"
+  rm -f ./vendor/ezsystems/ezplatform-i18n/flex-workflow/*
+  cp ./vendor/ezsystems/flex-workflow/bundle/Resources/translations/* ./vendor/ezsystems/ezplatform-i18n/flex-workflow
 fi
 
 if [ -d "./vendor/ezsystems/ezplatform-page-builder" ]; then
-  rm ./vendor/ezsystems/ezplatform-i18n/ezplatform-page-builder/*.xlf
-  cp ./vendor/ezsystems/ezplatform-page-builder/src/bundle/Resources/translations/*.xlf ./vendor/ezsystems/ezplatform-i18n/ezplatform-page-builder
+  echo "ezsystems/ezplatform-page-builder"
+  rm -f ./vendor/ezsystems/ezplatform-i18n/ezplatform-page-builder/*
+  cp ./vendor/ezsystems/ezplatform-page-builder/src/bundle/Resources/translations/* ./vendor/ezsystems/ezplatform-i18n/ezplatform-page-builder
 fi
 
 if [ -d "./vendor/ezsystems/ezplatform-page-fieldtype" ]; then
-  rm ./vendor/ezsystems/ezplatform-i18n/ezplatform-page-fieldtype/*.xlf
-  cp ./vendor/ezsystems/ezplatform-page-fieldtype/src/bundle/Resources/translations/*.xlf ./vendor/ezsystems/ezplatform-i18n/ezplatform-page-fieltype
+  echo "ezsystems/ezplatform-page-fieldtype"
+  rm -f ./vendor/ezsystems/ezplatform-i18n/ezplatform-page-fieldtype/*
+  cp ./vendor/ezsystems/ezplatform-page-fieldtype/src/bundle/Resources/translations/* ./vendor/ezsystems/ezplatform-i18n/ezplatform-page-fieldtype
 fi
 
+echo '# Fixing .xlf extensions'
+rename -s '.xliff' '.xlf' vendor/ezsystems/ezplatform-i18n/*/*
+
 echo '# Strip english locale suffix from filename';
-rename 's/\.en\./\./g' ./vendor/ezsystems/ezplatform-i18n/*/*
+rename -s '.en' '' ./vendor/ezsystems/ezplatform-i18n/*/*
 
 echo 'Translation synchronization done !';

--- a/bin/synchronize-translations.sh
+++ b/bin/synchronize-translations.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env sh
+# This script should be used to synchronize ezplatform-i18n repository
+# Translations must be up-to-date in all packages
+echo 'Translation synchronization';
+
+echo '# Clean corresponding ezplatform-i18n folder';
+rm -rf ./vendor/ezsystems/ezplatform-i18n/ezplatform-admin-ui/*.xlf
+rm -rf ./vendor/ezsystems/ezplatform-i18n/ezpublish-kernel/*.xlf
+rm -rf ./vendor/ezsystems/ezplatform-i18n/repository-forms/*.xlf
+
+echo '# Mirror the translation files';
+cp ./vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/translations/*.xliff ./vendor/ezsystems/ezplatform-i18n/ezplatform-admin-ui
+cp ./vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishCoreBundle/Resources/translations/*.xlf ./vendor/ezsystems/ezplatform-i18n/ezpublish-kernel
+cp ./vendor/ezsystems/repository-forms/bundle/Resources/translations/*.xlf ./vendor/ezsystems/ezplatform-i18n/repository-forms
+
+echo '# Fixing .xlf extensions'
+rename -s '.xliff' '.xlf' vendor/ezsystems/ezplatform-i18n/ezplatform-admin-ui/*
+
+if [ -d "./vendor/ezsystems/date-based-publisher" ]; then
+  echo "Sync ezsystems/date-based-publisher"
+  rm ./vendor/ezsystems/ezplatform-i18n/date-based-publisher/*.xlf
+  cp ./vendor/ezsystems/date-based-publisher/bundle/Resources/translations/*.xlf ./vendor/ezsystems/ezplatform-i18n/date-based-publisher
+fi
+
+if [ -d "./vendor/ezsystems/flex-workflow" ]; then
+  echo "Sync ezsystems/flex-workflow"
+  rm ./vendor/ezsystems/ezplatform-i18n/flex-workflow/*.xlf
+  cp ./vendor/ezsystems/flex-workflow/bundle/Resources/translations/*.xlf ./vendor/ezsystems/ezplatform-i18n/flex-workflow
+fi
+
+if [ -d "./vendor/ezsystems/ezplatform-page-builder" ]; then
+  rm ./vendor/ezsystems/ezplatform-i18n/ezplatform-page-builder/*.xlf
+  cp ./vendor/ezsystems/ezplatform-page-builder/src/bundle/Resources/translations/*.xlf ./vendor/ezsystems/ezplatform-i18n/ezplatform-page-builder
+fi
+
+if [ -d "./vendor/ezsystems/ezplatform-page-fieldtype" ]; then
+  rm ./vendor/ezsystems/ezplatform-i18n/ezplatform-page-fieldtype/*.xlf
+  cp ./vendor/ezsystems/ezplatform-page-fieldtype/src/bundle/Resources/translations/*.xlf ./vendor/ezsystems/ezplatform-i18n/ezplatform-page-fieltype
+fi
+
+echo '# Strip english locale suffix from filename';
+rename 's/\.en\./\./g' ./vendor/ezsystems/ezplatform-i18n/*/*
+
+echo 'Translation synchronization done !';

--- a/composer.json
+++ b/composer.json
@@ -8,5 +8,6 @@
     "branch-alias": {
       "dev-master": "2.0.x-dev"
     }
-  }
+  },
+  "bin": ["bin/synchronize-translations.sh"]
 }

--- a/docs/howto_publish_translations.md
+++ b/docs/howto_publish_translations.md
@@ -1,36 +1,69 @@
 # How-to publish translations
 
-Translations happen on [ezsystems/ezplatform-i18n](https://github.com/ezsystems/ezplatform-i18n). Changes made on crowdin will be committed to the `l10n_master` branch.
+Translations happen on [ezsystems/ezplatform-i18n](https://github.com/ezsystems/ezplatform-i18n).
+Changes made on crowdin are pushed to the `l10n_master` branch, and a pull-request is open.
+
+**DO NOT MERGE THE PULL REQUEST**
 
 ## Merging contributions from crowdin
 
-From the updated master branch, run `php bin/ezsystems/ezplatform-i18n` (requires the crowdin API key, available to managers from the [settings / API](https://crowdin.com/project/ezplatform/settings#api) page. The script will output git commands that add and commit changes to each language, with a progress percentage in the message:
+This procedure requires a **crowdin API key**. Those are available to
+managers from the [settings / API][crowdin_api_settings] page.
+
+The commands below must be executed from the `vendor/ezsystems/ezplatform-i18n` directory,
+and it must be a git working copy. If it is not, run:
+```
+rm -rf vendor/ezsystems/ezplatform-i18n
+composer update --prefer-source ezsystems/ezplatform-i18n
+```
+
+From the updated `master` branch, run `php bin/ezsystems/ezplatform-i18n/bin/split_language_commits`*[]:
+The script will output git commands that add and commit changes to each language,
+with a progress percentage in the message:
 
 ```
-php bin/split_language_commits.php                     
-No changes to Croatian (0% translated, 0% approved)
-No changes to English, United States (96% translated, 12% approved)
-No changes to Finnish (4% translated, 0% approved)
+$ php bin/split_language_commits.php
+
+# Croatian: no changes (0% translated, 0% approved)
+# English, United States: no changes (96% translated, 12% approved)
+# French (france): (99% translated, 94% approved)
 git checkout l10n_master translations/fr_FR/
 git commit -m "French translation (99% translated, 94% approved)"
+# German: (93% translated, 0% approved)
 git checkout l10n_master translations/de_DE/
 git commit -m "German translation (93% translated, 0% approved)"
-git checkout l10n_master translations/el_GR/
-git commit -m "Greek translation (22% translated, 0% approved)"
-No changes to Hindi (16% translated, 0% approved)
-No changes to Hungarian (99% translated, 99% approved)
-No changes to Italian (83% translated, 2% approved)
-git checkout l10n_master translations/ja_JP/
-git commit -m "Japanese translation (24% translated, 0% approved)"
-No changes to Norwegian Bokmal (99% translated, 0% approved)
-No changes to Polish (100% translated, 100% approved)
-No changes to Portuguese (96% translated, 96% approved)
-No changes to Russian (0% translated, 0% approved)
-No changes to Spanish (35% translated, 0% approved)
 ```
 
 Run the commands. Do a new tag if necessary, and push the changes.
 
+[crowdin_api_settings]: https://crowdin.com/project/ezplatform/settings#api
+
 ## Publishing changes to the languages repositories
 
-Follow the instructions for git subsplit in the README.md file.
+Each locale will be stored in its own repository,
+under the [ezplatform-i18n organisation][ezplatform-i18n-org].
+
+Synchronization is done using [dflydev/git-subsplit][dflydev].
+
+    git subsplit init https://github.com/ezsystems/ezplatform-i18n
+    git subsplit update
+    git subsplit publish "
+        translations/ach_UG:git@github.com:ezplatform-i18n/ezplatform-i18n-ach_UG.git
+        translations/de_DE:git@github.com:ezplatform-i18n/ezplatform-i18n-de_DE.git
+        translations/es_ES:git@github.com:ezplatform-i18n/ezplatform-i18n-es_ES.git
+        translations/el_GR:git@github.com:ezplatform-i18n/greek.git
+        translations/fi_FI:git@github.com:ezplatform-i18n/ezplatform-i18n-fi_FI.git
+        translations/fr_FR:git@github.com:ezplatform-i18n/ezplatform-i18n-fr_FR.git
+        translations/hi_IN:git@github.com:ezplatform-i18n/ezplatform-i18n-hi_IN.git
+        translations/hu_HU:git@github.com:ezplatform-i18n/ezplatform-i18n-hu_HU.git
+        translations/ja_JP:git@github.com:ezplatform-i18n/ezplatform-i18n-ja_JP.git
+        translations/nb_NO:git@github.com:ezplatform-i18n/ezplatform-i18n-nb_NO.git
+        translations/no_NO:git@github.com:ezplatform-i18n/ezplatform-i18n-no_NO.git
+        translations/pl_PL:git@github.com:ezplatform-i18n/ezplatform-i18n-pl_PL.git
+        translations/pt_PT:git@github.com:ezplatform-i18n/ezplatform-i18n-pt_PT.git
+        translations/ru_RU:git@github.com:ezplatform-i18n/ezplatform-i18n-ru_RU.git
+        translations/it_IT:git@github.com:ezplatform-i18n/ezplatform-i18n-it_IT.git
+        translations/en_US:git@github.com:ezplatform-i18n/ezplatform-i18n-en_US.git
+        translations/nl:git@github.com:ezplatform-i18n/dutch.git
+        translations/he:git@github.com:ezplatform-i18n/hebrew.git
+    " --heads=master


### PR DESCRIPTION
The script was in ezsystems/ezplatform. It belongs in here, as it not usable if ezsystems/ezplatform-i18n is not installed.

It would deserve a refactoring, but works as is :-)

### TODO
- [x] Test a full run: install from ezplatform, run `sh ./bin/synchronize-translations.sh` to sync ezplatform-i18n
- [x] Add `synchronize-translations.sh` to `bin/` when installed via composer.
- [x] Test with EE packages installed
- [ ] Remove from ezsystems/ezplatform (https://github.com/ezsystems/ezplatform/pull/296)
