### PR TITLE
Change crowdin configuration to introduce new filename pattern

### DIFF
--- a/bin/split_language_commits.php
+++ b/bin/split_language_commits.php
@@ -98,34 +98,6 @@ function getLanguagesData()
         'he' => 'he',
         'zh-HK' => 'zh_HK',
     ];
-
-    $translationsFilesRenamed = false;
-
-    foreach (glob("translations/*/*/*.xlf") as $filepath) {
-        if (!preg_match('|translations/([a-z]{2,3}_[a-z]{2,3})/(.*)\.([a-z]{2,3}_[a-z]{2,3})\.xlf|i', $filepath, $m)) {
-            continue;
-        }
-
-        if (in_array($m[3], $languagesMap, true)) {
-            $newfilepath = preg_replace_callback(
-                '|(.*\.)([a-z]{2,3}_[a-z]{2,3})(\.xlf)|i',
-                function ($matches) use ($languagesMap) {
-                    [, $dirName, $locale, $extension] = $matches;
-                    return $dirName . str_replace(array_values($languagesMap), array_keys($languagesMap), $locale) . $extension;
-                },
-                $filepath
-            );
-
-            $command = 'git mv $filepath {$newfilepath}';
-            system($command);
-            $translationsFilesRenamed = true;
-        }
-    }
-
-    if ($translationsFilesRenamed) {
-        system('git commit -m "Rename translations files."');
-    }
-
     if (!$crowdinApiKey = getenv('CROWDIN_API_KEY')) {
         throw new InvalidArgumentException("Environment variable CROWDIN_API_KEY must be set for the ezplatform project");
     }

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,35 +1,34 @@
 project_identifier: ezplatform
-files:
-  - source: /ezpublish-kernel/*.xlf
-    translation: >-
-      /translations/%locale_with_underscore%/%original_path%/%file_name%.%locale_with_underscore%.%file_extension%
-  - source: /repository-forms/*.xlf
-    translation: >-
-      /translations/%locale_with_underscore%/%original_path%/%file_name%.%locale_with_underscore%.%file_extension%
-  - source: /ezplatform-admin-ui/*.xlf
-    translation: >-
-      /translations/%locale_with_underscore%/%original_path%/%file_name%.%locale_with_underscore%.%file_extension%
-  - source: /date-based-publisher/*
-    translation: >-
-      /translations/%locale_with_underscore%/%original_path%/%file_name%.%locale_with_underscore%.%file_extension%
-  - source: /flex-workflow/*
-    translation: >-
-      /translations/%locale_with_underscore%/%original_path%/%file_name%.%locale_with_underscore%.%file_extension%
-  - source: /ezplatform-page-fieldtype/*
-    translation: >-
-      /translations/%locale_with_underscore%/%original_path%/%file_name%.%locale_with_underscore%.%file_extension%
-  - source: /ezplatform-page-builder/*
-    translation: >-
-      /translations/%locale_with_underscore%/%original_path%/%file_name%.%locale_with_underscore%.%file_extension%
-  - source: /ezplatform-admin-ui-modules
-    translation: >-
-      /translations/%locale_with_underscore%/%original_path%/%file_name%.%locale_with_underscore%.%file_extension%
-  - source: /ezplatform-form-builder/*.xlf
-    translation: >-
-      /translations/%locale_with_underscore%/%original_path%/%file_name%.%locale_with_underscore%.%file_extension%
-  - source: /ezplatform-workflow/*
-    translation: >-
-      /translations/%locale_with_underscore%/%original_path%/%file_name%.%locale_with_underscore%.%file_extension%
-  - source: /ezplatform-richtext/*
-    translation: >-
-      /translations/%locale_with_underscore%/%original_path%/%file_name%.%locale_with_underscore%.%file_extension%
+files: [
+    {
+        source: "/**/*.xlf",
+        translation: "/translations/%locale_with_underscore%/**/%file_name%.%locale_with_underscore%.%file_extension%",
+        languages_mapping: {
+            "locale": {
+                "en-US": "en_US",
+                "pl": "pl",
+                "de": "de",
+                "el": "el",
+                "es": "es",
+                "fi": "fi",
+                "fr": "fr",
+                "hi": "hi",
+                "hr": "hr",
+                "hu": "hu",
+                "it": "it",
+                "ja": "ja",
+                "nb": "nb",
+                "no": "no",
+                "nl": "nl",
+                "pt-PT": "pt",
+                "ru": "ru",
+                "zh-HK": "zh_HK"
+            }
+        },
+        ignore: [
+          "/translations",
+          "/bin",
+          "/docs"
+        ]
+    }
+]


### PR DESCRIPTION
To avoid changing filename with `git mv` this PR changes Crowdin configuration to introduce a new pattern for filenames with translation. Before this all filenames on branch l10n_master must be changed to avoid duplication of the files. 

[https://github.com/ezsystems/ezplatform-i18n/pull/46](https://github.com/ezsystems/ezplatform-i18n/pull/46)